### PR TITLE
Fix indefinite wait during StreamChannelGetArbitrationResp

### DIFF
--- a/p4rt_client/p4rt_client.go
+++ b/p4rt_client/p4rt_client.go
@@ -673,6 +673,9 @@ func (p *P4RTClient) StreamChannelGetArbitrationResp(streamName *string,
 	}
 
 	seqNum, respArbr = cStream.GetArbitration(minSeqNum)
+	if respArbr == nil {
+		return seqNum, nil, fmt.Errorf("%q Stream terminated: %s\n", p, *streamName)
+	}
 
 	return seqNum, respArbr, nil
 }
@@ -689,6 +692,9 @@ func (p *P4RTClient) StreamChannelGetPacket(streamName *string,
 	}
 
 	seqNum, pktInfo = cStream.GetPacket(minSeqNum)
+	if pktInfo == nil {
+		return seqNum, nil, fmt.Errorf("%q Stream terminated: %s\n", p, *streamName)
+	}
 
 	return seqNum, pktInfo, nil
 }


### PR DESCRIPTION
Issue:

If we call `StreamChannelGetArbitrationResp` directly after `StreamChannelCreate` and the device terminates the stream, the process indefinitely blocks on `func (p *P4RTClientStream) GetArbitration(minSeqNum uint64) (uint64, *P4RTArbInfo)`.

This happens because of the blocking `p.arbCond.Wait()`. The device would never return a response and hence `QueueArbt()` would never get called thus indefinitely blocking the process.

Solution:

We also need to `Signal()` those `Wait()` calls during `streamChannelDestroyInternal` and also check `ShouldStop()` so that `GetArbitration()` and `GetPacket()` doesn't block again on `Wait()`.

cc: @liulk@google.com