### PR TITLE
populate StreamTermErr before sending signal.

### DIFF
--- a/p4rt_client/p4rt_client.go
+++ b/p4rt_client/p4rt_client.go
@@ -200,16 +200,17 @@ func (p *P4RTClientStream) ShouldStop() bool {
 func (p *P4RTClientStream) Stop() {
 	p.stopMu.Lock()
 	p.stop = true
+	p.stopMu.Unlock()
 
-	// Signal any waiting GetArbitration or GetPacket routines.
+	// Signal waiting GetArbitration routines.
 	p.arb_mu.Lock()
 	p.arbCond.Signal()
 	p.arb_mu.Unlock()
+
+	// Signal waiting GetPacket routines.
 	p.pkt_mu.Lock()
 	p.pktCond.Signal()
 	p.pkt_mu.Unlock()
-
-	p.stopMu.Unlock()
 
 	// Force the RX Recv() to wake up
 	// (which would force the RX routing to Destroy and exit)


### PR DESCRIPTION
This would allow us to check the StreamTermErr without having to sleep after GetArbitration() or GetPacket() returns an error.