### PR TITLE
A way to Get All Packets at once with timeout

### DIFF
--- a/p4rt_client/p4rt_client.go
+++ b/p4rt_client/p4rt_client.go
@@ -793,7 +793,7 @@ func (p *P4RTClient) StreamChannelGetPackets(streamName *string,
 		}
 	}
 
-	return seqNum, pkts, nil
+	return seqNum, pkts, err
 }
 
 func (p *P4RTClient) SetForwardingPipelineConfig(msg *p4_v1.SetForwardingPipelineConfigRequest) error {

--- a/p4rt_client/p4rt_client.go
+++ b/p4rt_client/p4rt_client.go
@@ -353,8 +353,9 @@ func (p *P4RTClientStream) GetPacketsWithTimeout(minSeqNum uint64, timeout time.
 	done := make(chan struct{})
 	defer close(done)
 	var failed atomic.Bool
-	failed.Load()
 
+	// routine returns directly if 'done' else updates 'failed'
+	// and signals pktCond.
 	go func() {
 		select {
 		case <-done:
@@ -368,6 +369,7 @@ func (p *P4RTClientStream) GetPacketsWithTimeout(minSeqNum uint64, timeout time.
 	p.pkt_mu.Lock()
 	defer p.pkt_mu.Unlock()
 	for p.pktCounters.RxPktCntr < minSeqNum {
+		// if timeout then loop breaks here.
 		if failed.Load() {
 			break
 		}


### PR DESCRIPTION
## Description

Current StreamChannelGetPacket() tries to get one single packet from Queue. It allows a `minSeqNum` which is the highest count of the packet received. However, the returned packet may not be the packet with that count. Additionally, the call blocks indefinitely if `minSeqNum` packets are not received.

I propose, we have a `StreamChannelGetPackets()` method that allows getting all current packets in Queue, that also waits for a `definite` amount of time if the Queue doesn't have  the `minSeqNum` amount of packets.

## Type of Change

- [x] New Feature

## Checklist

- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] All new and existing tests pass
