### PR TITLE
Update function P4InfoLoad to return pointer instead of value

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func main() {
 		ElectionId: arbMsg1.Arb.ElectionId,
 		Action:     p4_v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4_v1.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4_v1.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/utils/utilities.go
+++ b/utils/utilities.go
@@ -25,7 +25,7 @@ import (
 	"io/ioutil"
 )
 
-func P4InfoLoad(fileName *string) (p4_v1_config.P4Info, error) {
+func P4InfoLoad(fileName *string) (*p4_v1_config.P4Info, error) {
 	var p4Info p4_v1_config.P4Info
 
 	p4infoFile, err := ioutil.ReadFile(*fileName)
@@ -34,6 +34,5 @@ func P4InfoLoad(fileName *string) (p4_v1_config.P4Info, error) {
 	} else {
 		err = prototext.Unmarshal(p4infoFile, &p4Info)
 	}
-
-	return p4Info, err
+	return &p4Info, err
 }


### PR DESCRIPTION
## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.
P4InfoLoad function is returning P4Info structure value instead of the pointer, which goes against the style guide
https://github.com/cisco-open/go-p4/issues/16

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
